### PR TITLE
bump up ssm version due to deploy mistake

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-simple-middleware",
   "description": "Simple middleware to translate the interface of lambda's handler to request => response",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "VoyagerX",


### PR DESCRIPTION
0.0.49를 배포하다가 npm run build를 하지 않고 npm publish를 해버려서 dist를 생성해주고 버전업 해준뒤 재배포했습니다 - 현재는 0.0.50버전으로 정상배포된 상태입니다.