### PR TITLE
(VREW-10017) add custom header for http response.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-simple-middleware",
   "description": "Simple middleware to translate the interface of lambda's handler to request => response",
-  "version": "0.0.58",
+  "version": "0.0.60",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "VoyagerX",

--- a/src/middleware/base.ts
+++ b/src/middleware/base.ts
@@ -50,30 +50,33 @@ export class HandlerRequest {
   }
 }
 
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'X-Version',
+  'Access-Control-Allow-Credentials': true,
+};
+
 export class HandlerResponse {
   public callback: any;
   public completed: boolean;
   public result: any | Promise<any> | undefined;
 
-  private corsHeaders: { [header: string]: any };
   private cookies: string[];
   private crossOrigin?: string;
+  private customHeaders: { [header: string]: any };
 
   constructor(callback: any) {
     this.callback = callback;
     this.completed = false;
-    this.corsHeaders = {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Headers': 'X-Version',
-      'Access-Control-Allow-Credentials': true,
-    };
     this.cookies = [];
+    this.customHeaders = {};
   }
 
   public ok(body = {}, code = 200) {
     logger.stupid(`ok`, body);
     const headers = {
-      ...this.corsHeaders,
+      ...CORS_HEADERS,
+      ...this.customHeaders,
     };
     if (this.crossOrigin) {
       headers['Access-Control-Allow-Origin'] = this.crossOrigin;
@@ -96,7 +99,7 @@ export class HandlerResponse {
     logger.stupid(`fail`, body);
     const result = this.callback(null, {
       statusCode: code,
-      headers: this.corsHeaders,
+      headers: CORS_HEADERS,
       body: JSON.stringify(body),
     });
     this.completed = true;
@@ -123,6 +126,10 @@ export class HandlerResponse {
 
   public setCrossOrigin = (origin?: string) => {
     this.crossOrigin = origin;
+  };
+
+  public addHeader = (header: string, value: string) => {
+    this.customHeaders[header] = value;
   };
 }
 


### PR DESCRIPTION
http 302 (redirect) 를 구현하기 위해, http response 객체에 헤더를 추가하는 addHeader() 함수를 추가하였습니다.

예전 kysely 는 바로 revert 하고 그 위에 올린 것이라 0.0.60 으로 버전이 바로 올라갔습니다.