### PR TITLE
Introduce new method to destroy DB connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-simple-middleware",
   "description": "Simple middleware to translate the interface of lambda's handler to request => response",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "author": "VoyagerX",

--- a/src/middleware/database/connectionProxy.ts
+++ b/src/middleware/database/connectionProxy.ts
@@ -102,6 +102,10 @@ export class ConnectionProxy {
     }
   };
 
+  /**
+   * Destroy the connection socket immediately. No further events or callbacks will be triggered.
+   * This should be used only for special use cases!
+   */
   public destroyConnection = () => {
     if (this.connection) {
       this.connection.destroy();

--- a/src/middleware/database/connectionProxy.ts
+++ b/src/middleware/database/connectionProxy.ts
@@ -102,6 +102,14 @@ export class ConnectionProxy {
     }
   };
 
+  public destroyConnection = () => {
+    if (this.connection) {
+      this.connection.destroy();
+      this.connection = undefined;
+      logger.verbose('Connection is destroyed');
+    }
+  };
+
   public onPluginCreated = async () => this.tryToInitializeSchema(true);
 
   private prepareConnection = () => {

--- a/src/middleware/database/sqlClient.ts
+++ b/src/middleware/database/sqlClient.ts
@@ -90,11 +90,9 @@ export class SQLClient<T = unknown> extends Kysely<T> {
    * Destroy the connection socket immediately. No further events or callbacks will be triggered.
    * This should be used only for special use cases!
    */
-  public destroyConnection = () =>
-    new Promise<void>((resolve) => {
-      this.pool.destroy();
-      resolve();
-    });
+  public destroyConnection = (): void => {
+    this.pool.destroy();
+  };
 }
 
 export {

--- a/src/middleware/database/sqlClient.ts
+++ b/src/middleware/database/sqlClient.ts
@@ -50,6 +50,13 @@ class LazyConnectionPool implements MysqlPool {
     }
   };
 
+  public destroy = (): void => {
+    if (this.connection) {
+      this.connection.destroy();
+      this.connection = null;
+    }
+  };
+
   private _addRelease = (connection: Connection): LazyMysqlPoolConnection =>
     Object.assign(connection, {
       release: () => {},
@@ -77,6 +84,16 @@ export class SQLClient<T = unknown> extends Kysely<T> {
   public clearConnection = () =>
     new Promise<void>((resolve) => {
       this.pool.end(() => resolve());
+    });
+
+  /**
+   * Destroy the connection socket immediately. No further events or callbacks will be triggered.
+   * This should be used only for special use cases!
+   */
+  public destroyConnection = () =>
+    new Promise<void>((resolve) => {
+      this.pool.destroy();
+      resolve();
     });
 }
 


### PR DESCRIPTION
DB 연결을 동기적으로 강제 종료하기 위한 메서드를 추가합니다.

https://v6x.slack.com/archives/CH32A6T2Q/p1753857633165749

이 이슈 스레드에서 제가, auth 핸들러 쪽 코드에서

```typescript
  } finally {
    db.clearConnection();
  }
```

이런 식으로 응답 반환 전에 연결을 닫아 주면 해결될 것 같다고 공유했었는데요
실제로 적용 후 확인해 보니까 해결이 되지 않았습니다.
이유를 찾아 보니, mysql 라이브러리의 `connection.end()` 메서드는 콜백 기반이라서 호출해도 이벤트 루프에 등록이 될 뿐
루프가 freeze 가 되면 결국 실행이 되지 않는 것은 동일했습니다.

따라서 동기적으로 즉시 연결을 종료할 방법이 필요한데,
mysql / mysql2 에는 동기 종료 메서드가 있기는 한데 저희 서심미에는 등록이 되어있지 않아서 이 PR로 추가합니다.